### PR TITLE
Feature/fix c array type size

### DIFF
--- a/assets/classes/hkVertexFormat.json
+++ b/assets/classes/hkVertexFormat.json
@@ -183,7 +183,7 @@
       "vsubtype": "TYPE_VOID",
       "offset_x86": 0,
       "offset_x86_64": 0,
-      "type_size_x86": 8,
+      "type_size_x86": 256,
       "type_size_x86_64": 256,
       "arrsize": 32,
       "flags": "FLAGS_NONE",

--- a/assets/classes/hkbGeneratorSyncInfo.json
+++ b/assets/classes/hkbGeneratorSyncInfo.json
@@ -17,8 +17,8 @@
       "vsubtype": "TYPE_VOID",
       "offset_x86": 0,
       "offset_x86_64": 0,
-      "type_size_x86": 8,
-      "type_size_x86_64": 8,
+      "type_size_x86": 64,
+      "type_size_x86_64": 64,
       "arrsize": 8,
       "flags": "FLAGS_NONE",
       "default": 0

--- a/assets/classes/hkpVehicleFrictionDescription.json
+++ b/assets/classes/hkpVehicleFrictionDescription.json
@@ -45,7 +45,7 @@
       "vsubtype": "TYPE_VOID",
       "offset_x86": 8,
       "offset_x86_64": 8,
-      "type_size_x86": 100,
+      "type_size_x86": 200,
       "type_size_x86_64": 200,
       "arrsize": 2,
       "flags": "FLAGS_NONE",

--- a/assets/classes/hkpVehicleFrictionStatus.json
+++ b/assets/classes/hkpVehicleFrictionStatus.json
@@ -17,7 +17,7 @@
       "vsubtype": "TYPE_VOID",
       "offset_x86": 0,
       "offset_x86_64": 0,
-      "type_size_x86": 36,
+      "type_size_x86": 72,
       "type_size_x86_64": 72,
       "arrsize": 2,
       "flags": "FLAGS_NONE",

--- a/crates/havok_classes/src/generated/hkVertexFormat_.rs
+++ b/crates/havok_classes/src/generated/hkVertexFormat_.rs
@@ -21,7 +21,7 @@ pub struct hkVertexFormat {
     /// # C++ Info
     /// - name: `elements`(ctype: `struct hkVertexFormatElement[32]`)
     /// - offset: `  0`(x86)/`  0`(x86_64)
-    /// - type_size: `  8`(x86)/`256`(x86_64)
+    /// - type_size: `256`(x86)/`256`(x86_64)
     pub m_elements: [hkVertexFormatElement; 32usize],
     /// # C++ Info
     /// - name: `numElements`(ctype: `hkInt32`)
@@ -72,7 +72,6 @@ const _: () = {
                         size_x86_64: 8u64,
                     },
                 )?;
-            serializer.pad_field([0u8; 248usize].as_slice(), [0u8; 0usize].as_slice())?;
             serializer.serialize_field("numElements", &self.m_numElements)?;
             serializer.end()
         }
@@ -188,7 +187,6 @@ const _: () = {
                                         ),
                                     );
                                 }
-                                __A::pad(&mut __map, 248usize, 0usize)?;
                                 m_numElements = _serde::__private::Some(
                                     match __A::next_value::<i32>(&mut __map) {
                                         _serde::__private::Ok(__val) => __val,

--- a/crates/havok_classes/src/generated/hkbGeneratorSyncInfo_.rs
+++ b/crates/havok_classes/src/generated/hkbGeneratorSyncInfo_.rs
@@ -21,7 +21,7 @@ pub struct hkbGeneratorSyncInfo {
     /// # C++ Info
     /// - name: `syncPoints`(ctype: `struct hkbGeneratorSyncInfoSyncPoint[8]`)
     /// - offset: `  0`(x86)/`  0`(x86_64)
-    /// - type_size: `  8`(x86)/`  8`(x86_64)
+    /// - type_size: ` 64`(x86)/` 64`(x86_64)
     pub m_syncPoints: [hkbGeneratorSyncInfoSyncPoint; 8usize],
     /// # C++ Info
     /// - name: `baseFrequency`(ctype: `hkReal`)
@@ -102,7 +102,6 @@ const _: () = {
                         size_x86_64: 8u64,
                     },
                 )?;
-            serializer.pad_field([0u8; 56usize].as_slice(), [0u8; 56usize].as_slice())?;
             serializer.serialize_field("baseFrequency", &self.m_baseFrequency)?;
             serializer.serialize_field("localTime", &self.m_localTime)?;
             serializer.serialize_field("playbackSpeed", &self.m_playbackSpeed)?;
@@ -245,7 +244,6 @@ const _: () = {
                                         ),
                                     );
                                 }
-                                __A::pad(&mut __map, 56usize, 56usize)?;
                                 m_baseFrequency = _serde::__private::Some(
                                     match __A::next_value::<f32>(&mut __map) {
                                         _serde::__private::Ok(__val) => __val,

--- a/crates/havok_classes/src/generated/hkpVehicleFrictionDescription_.rs
+++ b/crates/havok_classes/src/generated/hkpVehicleFrictionDescription_.rs
@@ -31,7 +31,7 @@ pub struct hkpVehicleFrictionDescription {
     /// # C++ Info
     /// - name: `axleDescr`(ctype: `struct hkpVehicleFrictionDescriptionAxisDescription[2]`)
     /// - offset: `  8`(x86)/`  8`(x86_64)
-    /// - type_size: `100`(x86)/`200`(x86_64)
+    /// - type_size: `200`(x86)/`200`(x86_64)
     pub m_axleDescr: [hkpVehicleFrictionDescriptionAxisDescription; 2usize],
 }
 const _: () = {
@@ -83,7 +83,6 @@ const _: () = {
                         size_x86_64: 100u64,
                     },
                 )?;
-            serializer.pad_field([0u8; 100usize].as_slice(), [0u8; 0usize].as_slice())?;
             serializer.end()
         }
     }
@@ -234,7 +233,6 @@ const _: () = {
                             _ => {}
                         }
                     }
-                    __A::pad(&mut __map, 100usize, 0usize)?;
                     let m_wheelDistance = match m_wheelDistance {
                         _serde::__private::Some(__field) => __field,
                         _serde::__private::None => {

--- a/crates/havok_classes/src/generated/hkpVehicleFrictionStatus_.rs
+++ b/crates/havok_classes/src/generated/hkpVehicleFrictionStatus_.rs
@@ -21,7 +21,7 @@ pub struct hkpVehicleFrictionStatus {
     /// # C++ Info
     /// - name: `axis`(ctype: `struct hkpVehicleFrictionStatusAxisStatus[2]`)
     /// - offset: `  0`(x86)/`  0`(x86_64)
-    /// - type_size: ` 36`(x86)/` 72`(x86_64)
+    /// - type_size: ` 72`(x86)/` 72`(x86_64)
     pub m_axis: [hkpVehicleFrictionStatusAxisStatus; 2usize],
 }
 const _: () = {
@@ -71,7 +71,6 @@ const _: () = {
                         size_x86_64: 36u64,
                     },
                 )?;
-            serializer.pad_field([0u8; 36usize].as_slice(), [0u8; 0usize].as_slice())?;
             serializer.end()
         }
     }
@@ -180,7 +179,6 @@ const _: () = {
                             _ => {}
                         }
                     }
-                    __A::pad(&mut __map, 36usize, 0usize)?;
                     let m_axis = match m_axis {
                         _serde::__private::Some(__field) => __field,
                         _serde::__private::None => {


### PR DESCRIPTION
# New Features

# Changes and Fixes

Fix incorrect size calculation of C array member of structure.

Below are the C++ classes affected by this fix.
- hkbGeneratorSyncInfo, hkpVehicleFrictionDescription, hkpVehicleFrictionStatus, hkVertexFormat

# Refactors
