### PR TITLE
refactor(de-parser): change winnow parser usage

### DIFF
--- a/serde_hkx/src/bytes/de/mod.rs
+++ b/serde_hkx/src/bytes/de/mod.rs
@@ -456,7 +456,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut BytesDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        let res = visitor.visit_bool(tri!(self.parse_peek(boolean())));
+        let res = visitor.visit_bool(tri!(self.parse_peek(boolean)));
         self.current_position += 1;
         res
     }
@@ -742,7 +742,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut BytesDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        let s = tri!(self.parse_local_fixup(string())).map_or_else(
+        let s = tri!(self.parse_local_fixup(string)).map_or_else(
             || {
                 #[cfg(feature = "tracing")]
                 tracing::debug!("CString is NullPtr");
@@ -795,7 +795,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut BytesDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        let s = tri!(self.parse_local_fixup(string())).map_or_else(
+        let s = tri!(self.parse_local_fixup(string)).map_or_else(
             || {
                 #[cfg(feature = "tracing")]
                 tracing::debug!("StringPtr is NullPtr");

--- a/serde_hkx/src/bytes/de/parser/classnames.rs
+++ b/serde_hkx/src/bytes/de/parser/classnames.rs
@@ -43,7 +43,7 @@ pub fn classnames_section<'a>(
                 _: binary::u8::<&[u8], ContextError>
                     .verify(|byte| *byte == 0x9)
                     .context(StrContext::Expected(Description("class name separator(0x9)"))),
-                string() // Parse until `\0`
+                string // Parse until `\0`
                     .verify(|s: &str| s.is_ascii())
                     .context(StrContext::Expected(Description("ASCII class name(e.g. `hkReferencedObject`")))
             }.parse_next(bytes));

--- a/serde_hkx/src/lib.rs
+++ b/serde_hkx/src/lib.rs
@@ -19,8 +19,6 @@ mod lib {
     pub use self::core::f32;
     pub use self::core::fmt;
     pub use self::core::fmt::Display;
-    pub use self::core::ops::AddAssign;
-    pub use self::core::ops::MulAssign;
     pub use self::core::ops::Range;
     pub use self::core::str;
     pub use self::core::str::FromStr;

--- a/serde_hkx/src/xml/de/class_index_map.rs
+++ b/serde_hkx/src/xml/de/class_index_map.rs
@@ -33,7 +33,7 @@ impl<'a, 'de> ClassIndexAccess<'de> for ClassIndexMapDeserializer<'a, 'de> {
     type Error = Error;
 
     fn next_key(&mut self) -> Result<&'de str, Self::Error> {
-        let (_ptr, class_name, _signature) = tri!(self.de.parse_peek(class_start_tag()));
+        let (_ptr, class_name, _signature) = tri!(self.de.parse_peek(class_start_tag));
         Ok(class_name)
     }
 

--- a/serde_hkx/src/xml/de/map.rs
+++ b/serde_hkx/src/xml/de/map.rs
@@ -84,7 +84,7 @@ impl<'a, 'de> MapAccess<'de> for MapDeserializer<'a, 'de> {
         // HACK: If the `strict` feature is disabled, fall back to the default value
         // if there is an error retrieving the value in the `havok_classes` crate, so check
         // for `>` here and omit the implementation of the `/>` shorthand notation.
-        let _len = tri!(self.de.parse_next(field_start_close_tag())); // Parse `>` or ` numelements="3">`
+        let _len = tri!(self.de.parse_next(field_start_close_tag)); // Parse `>` or ` numelements="3">`
         #[cfg(feature = "tracing")]
         if let Some(numelements) = _len {
             tracing::debug!(numelements);
@@ -99,7 +99,7 @@ impl<'a, 'de> MapAccess<'de> for MapDeserializer<'a, 'de> {
     fn skip_value_seed(&mut self) -> std::result::Result<(), Self::Error> {
         let (_num, _value) = tri!(self.de.parse_next(alt((
             winnow::seq! {
-                field_start_close_tag(), // Parse `>` or ` numelements="3">`
+                field_start_close_tag, // Parse `>` or ` numelements="3">`
                 take_until(0.., "<"),    // take any value
                 _: end_tag("hkparam")       // </hkparam>
             },

--- a/serde_hkx/src/xml/de/mod.rs
+++ b/serde_hkx/src/xml/de/mod.rs
@@ -252,7 +252,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut XmlDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        let key = tri!(self.parse_next(attr_string()));
+        let key = tri!(self.parse_next(attr_string));
         #[cfg(feature = "tracing")]
         tracing::debug!(key);
 
@@ -407,7 +407,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut XmlDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_pointer(tri!(self.parse_next(pointer())))
+        visitor.visit_pointer(tri!(self.parse_next(pointer)))
     }
 
     fn deserialize_array<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -473,7 +473,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut XmlDeserializer<'de> {
             tri!(self.parse_next(start_tag("hkobject")));
             None
         } else {
-            let (ptr_name, class_name, _signature) = tri!(self.parse_next(class_start_tag()));
+            let (ptr_name, class_name, _signature) = tri!(self.parse_next(class_start_tag));
             #[cfg(feature = "tracing")]
             tracing::trace!(
                 "Parsed: <hkobject name=\"{ptr_name}\" class=\"{class_name}\" signature=\"{_signature}\">"
@@ -502,7 +502,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut XmlDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_pointer(tri!(self.parse_next(pointer())))
+        visitor.visit_pointer(tri!(self.parse_next(pointer)))
     }
 
     fn deserialize_cstring<V>(self, visitor: V) -> Result<V::Value, Self::Error>

--- a/serde_hkx/src/xml/de/parser/tag.rs
+++ b/serde_hkx/src/xml/de/parser/tag.rs
@@ -1,16 +1,16 @@
 //! XML tag parsers
 use crate::lib::*;
 
-use super::type_kind::pointer;
 use super::{
     delimited_comment_multispace0, delimited_multispace0_comment, delimited_with_multispace0,
+    type_kind::pointer,
 };
 use havok_types::{Pointer, Signature};
 use winnow::ascii::{digit1, hex_digit1, oct_digit1};
 use winnow::combinator::{delimited, dispatch, fail, seq};
 use winnow::error::{ContextError, StrContext, StrContextValue, StrContextValue::*};
 use winnow::token::{take, take_until};
-use winnow::Parser;
+use winnow::{PResult, Parser};
 
 /// Parses the start tag `<tag>`
 pub fn start_tag<'a>(tag: &'static str) -> impl Parser<&'a str, (), ContextError> {
@@ -39,22 +39,25 @@ pub fn end_tag<'a>(tag: &'static str) -> impl Parser<&'a str, (), ContextError> 
 ///
 /// # Returns
 /// ([`Pointer`], ClassName, [`Signature`]) -> e.g. (`#0010`, `"hkbProjectData"`, `0x13a39ba7`)
-pub fn class_start_tag<'a>() -> impl Parser<&'a str, (Pointer, &'a str, Signature), ContextError> {
+///
+/// # Errors
+/// When parse failed.
+pub fn class_start_tag<'a>(input: &mut &'a str) -> PResult<(Pointer, &'a str, Signature)> {
     seq!(
         _: delimited_comment_multispace0("<"),
         _: delimited_with_multispace0("hkobject"),
         _: delimited_with_multispace0("name"),
         _: delimited_with_multispace0("="),
-        attr_ptr(),
+        attr_ptr,
 
         _: delimited_with_multispace0("class"),
         _: delimited_with_multispace0("="),
-        attr_string(),
+        attr_string,
 
         _: delimited_with_multispace0("signature"),
         _: delimited_with_multispace0("="),
         _: delimited_with_multispace0("\""),
-        radix_digits().map(|digits| Signature::new(digits as u32)),
+        radix_digits.map(|digits| Signature::new(digits as u32)),
         _: delimited_with_multispace0("\""),
         _: delimited_multispace0_comment(">")
     )
@@ -62,6 +65,7 @@ pub fn class_start_tag<'a>() -> impl Parser<&'a str, (Pointer, &'a str, Signatur
     .context(StrContext::Expected(StrContextValue::Description(
         r##"e.g. `<hkobject name="#0010" class="hkbProjectData" signature="0x13a39ba7">`"##,
     )))
+    .parse_next(input)
 }
 
 /// Parses the field of class start opening tag `<hkparam name=`
@@ -85,13 +89,16 @@ pub fn field_start_open_tag<'a>(
 }
 
 /// Parses the field of class start closing tag `>` or `numelements="0">`
-pub fn field_start_close_tag<'a>() -> impl Parser<&'a str, Option<u64>, ContextError> {
+///
+/// # Errors
+/// When parse failed.
+pub fn field_start_close_tag(input: &mut &str) -> PResult<Option<u64>> {
     seq!(
         winnow::combinator::opt(
             seq!(
                 _: delimited_with_multispace0("numelements"),
                 _: delimited_with_multispace0("="),
-                number_in_string::<u64>(), // e.g. "8"
+                number_in_string::<u64>, // e.g. "8"
             )
         ),
         _: delimited_multispace0_comment(">")
@@ -101,6 +108,7 @@ pub fn field_start_close_tag<'a>() -> impl Parser<&'a str, Option<u64>, ContextE
     .context(StrContext::Expected(StrContextValue::Description(
         "e.g. `>`",
     )))
+    .parse_next(input)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -108,30 +116,44 @@ pub fn field_start_close_tag<'a>() -> impl Parser<&'a str, Option<u64>, ContextE
 // There are support functions that exists only to parse the attributes in the tag.
 
 /// Parses a number inside a string, e.g., `"64"`
-fn number_in_string<'a, Num>() -> impl Parser<&'a str, Num, ContextError>
+///
+/// # Errors
+/// When parse failed.
+fn number_in_string<Num>(input: &mut &str) -> PResult<Num>
 where
-    Num: AddAssign<Num> + MulAssign<Num> + From<u8> + FromStr,
+    Num: FromStr,
 {
-    attr_string()
+    attr_string
         .parse_to()
         .context(StrContext::Label("number in string"))
         .context(StrContext::Expected(Description(r#"Number(e.g. `"64"`)"#)))
+        .parse_next(input)
 }
 
 /// Parses a xml attribute string(surrounded double quotes), e.g. `"string"`
-pub fn attr_string<'a>() -> impl Parser<&'a str, &'a str, ContextError> {
+///
+/// # Errors
+/// When parse failed.
+pub fn attr_string<'a>(input: &mut &'a str) -> PResult<&'a str> {
     delimited("\"", take_until(0.., "\""), "\"")
         .context(StrContext::Label("String in XML attribute"))
         .context(StrContext::Expected(Description(r#"String(e.g. `"Str"`)"#)))
+        .parse_next(input)
 }
 
 /// Parser a xml attribute pointer in string, e.g. `"#0050"`
-fn attr_ptr<'a>() -> impl Parser<&'a str, Pointer, ContextError> {
-    delimited("\"", pointer(), "\"")
+///
+/// # Errors
+/// When parse failed.
+fn attr_ptr(input: &mut &str) -> PResult<Pointer> {
+    delimited("\"", pointer, "\"").parse_next(input)
 }
 
 /// Parse radix digits. e.g. `0b101`, `0xff`
-fn radix_digits<'a>() -> impl Parser<&'a str, usize, ContextError> {
+///
+/// # Errors
+/// When parse failed.
+fn radix_digits(input: &mut &str) -> PResult<usize> {
     dispatch!(take(2_usize);
         "0b" | "0B" => digit1.try_map(|s| usize::from_str_radix(s, 2))
                         .context(StrContext::Label("digit")).context(StrContext::Expected(StrContextValue::Description("binary"))),
@@ -146,7 +168,7 @@ fn radix_digits<'a>() -> impl Parser<&'a str, usize, ContextError> {
                 .context(StrContext::Expected(StrContextValue::StringLiteral("0o")))
                 .context(StrContext::Expected(StrContextValue::StringLiteral("0d")))
                 .context(StrContext::Expected(StrContextValue::StringLiteral("0x"))),
-    )
+    ).parse_next(input)
 }
 
 #[cfg(test)]
@@ -156,9 +178,9 @@ mod tests {
 
     #[test]
     fn test_radix_digits() {
-        assert_eq!(radix_digits().parse("0b001010"), Ok(10));
-        assert_eq!(radix_digits().parse("0o57"), Ok(47));
-        assert_eq!(radix_digits().parse("0x1234"), Ok(4660));
+        assert_eq!(radix_digits.parse("0b001010"), Ok(10));
+        assert_eq!(radix_digits.parse("0o57"), Ok(47));
+        assert_eq!(radix_digits.parse("0x1234"), Ok(4660));
     }
 
     #[test]
@@ -186,7 +208,7 @@ mod tests {
     #[test]
     fn test_parse_array_start_close_tag() {
         fn test_parse(input: &str, expected: Option<u64>) {
-            match field_start_close_tag()
+            match field_start_close_tag
                 .parse(input)
                 .map_err(|e| ReadableError::from_parse(e, input).to_string())
             {
@@ -209,8 +231,8 @@ mod tests {
 
     #[test]
     fn test_parse_number_in_string() {
-        assert_eq!(number_in_string().parse(r#""33""#), Ok(33));
-        assert_eq!(number_in_string().parse(r#""100""#), Ok(100));
-        assert_eq!(number_in_string().parse(r#""0""#), Ok(0));
+        assert_eq!(number_in_string.parse(r#""33""#), Ok(33));
+        assert_eq!(number_in_string.parse(r#""100""#), Ok(100));
+        assert_eq!(number_in_string.parse(r#""0""#), Ok(0));
     }
 }


### PR DESCRIPTION
# Refactors
If we don't need arguments, use `PResult` instead of `impl Parser` to make it easier to see.