### PR TITLE
bumped version to 0.7.2, fixed handling shorthand closing tags, fixed…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/SARDONYX-sard/serde-hkx"                     # NOTE: Without it, CLI & CI build will error.
 rust-version = "1.85"
-version = "0.7.1"
+version = "0.7.2"
 
 [workspace]
 members = [


### PR DESCRIPTION
# New Features

# Changes and Fixes
Now handles shorthand closed XML tags like `/>`

Fixed parsing integers inside of tuples instead of floats, for example like when hkxconv is used to dump from SSE to XML

Bumped to 0.7.2, I think.

# Refactors
